### PR TITLE
Collect files in a sorted manner.

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -12,6 +12,7 @@ import           System.FilePath                ( (</>) )
 
 import qualified Data.ByteString.Lazy          as LBS
 import qualified Data.ByteString.Lazy.Char8    as LC
+import Data.List (sort)
 
 main :: IO ()
 main = getArgs >>= \case
@@ -42,9 +43,10 @@ templatize folder = do
 
 getFilesInDirectory :: FilePath -> IO [FilePath]
 getFilesInDirectory baseDirectory = do
-    basePaths <- listDirectory baseDirectory
+    basePaths <- listDirSorted baseDirectory
     concat <$> mapM (recursiveList "") basePaths
   where
+    listDirSorted = fmap sort . listDirectory
     recursiveList :: String -> FilePath -> IO [FilePath]
     recursiveList parentDir path = do
         let templatePath = parentDir </> path
@@ -52,7 +54,7 @@ getFilesInDirectory baseDirectory = do
         isDirectory <- doesDirectoryExist fullPath
         if isDirectory
             then do
-                files <- listDirectory fullPath
+                files <- listDirSorted fullPath
                 concat <$> mapM (recursiveList templatePath) files
             else return [templatePath]
 


### PR DESCRIPTION
This makes hsfiles hermetically (from file system) built / diff friendly,
since under the hood `listDirectory` calls `readdir`[1], which
doesn't appear to give any order guarantee[2].

1: https://github.com/haskell/unix/blob/43acabe288f58e3d8c9c71e15d4dd7b586e26efb/cbits/HsUnix.c
2: https://stackoverflow.com/q/8977441/315302

Side note: not sure what formatter this project is using, so I choose not to do the hassle manually.